### PR TITLE
DOPS-18304 Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/linter.yml
+++ b/.github/linter.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with: 
           fetch-depth: 0
       

--- a/.github/workflows/gmail-test.yml
+++ b/.github/workflows/gmail-test.yml
@@ -42,7 +42,7 @@ jobs:
           coverage: xdebug
           tools: php-cs-fixer, phpunit:${{ matrix.phpunit-versions }}
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: composer install --prefer-dist
       - name: Test


### PR DESCRIPTION
## Summary of changes
https://orchard.atlassian.net/browse/DOPS-18304

Bumps GitHub Actions still running on deprecated Node.js runtimes ahead of GitHub's hard removal deadline (Sept 16, 2026).

| Action | From | To | Runtime change |
|---|---|---|---|
| `actions/checkout` | `@v3` | `@v6` | node16 -> node24 |

### Areas to focus on
- **`.github/linter.yml` is dead config, flagging not fixing further**: it lives at `.github/linter.yml`, not `.github/workflows/linter.yml` - GitHub Actions only discovers workflow files under `.github/workflows/`, so this file has never actually run regardless of content. Its trigger also references a `test2` branch that doesn't exist in this repo. Bumped `checkout@v3`→`v6` here anyway for source-tree consistency, but this file has no real CI effect either way.
- `github/super-linter@v4` verified as docker-based - not affected by the node20 deprecation, left unchanged.
- `shivammathur/setup-php@v2` (in `gmail-test.yml`) verified already node24 - no change needed.

### Notes for code owners
No action required. Workflow infrastructure only - no application code affected.

### Breaking changes
None.
